### PR TITLE
Fixed python 3.5 build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ urllib3==1.24.2
 waitress==1.4.3
 Werkzeug==0.16.1
 wrapt==1.10.11
-scipy==1.5.0
+scipy==1.4.1


### PR DESCRIPTION
scipy library downgraded from 1.5.0 to 1.4.1 avaiable in python 3.5